### PR TITLE
primaryattack tweaks

### DIFF
--- a/lua/arccw/shared/attachments/default.lua
+++ b/lua/arccw/shared/attachments/default.lua
@@ -423,6 +423,7 @@ att.Override_MuzzleEffect = nil
 att.Override_FastMuzzleEffect = nil
 att.Override_GMMuzzleEffect = nil
 
+att.Override_ShellEffect = nil
 att.Override_ShellMaterial = nil
 
 att.Override_MuzzleEffectAttachment = nil

--- a/lua/weapons/arccw_base/sh_firing.lua
+++ b/lua/weapons/arccw_base/sh_firing.lua
@@ -584,7 +584,9 @@ function SWEP:GetDispersion()
 end
 
 function SWEP:DoShellEject()
-	if self.ShellEffect and self.ShellEffect == "NONE" then return end
+	local Eff = self:GetBuff_Override("Override_ShellEffect") or "arccw_shelleffect"
+	
+	if Eff == "NONE" then return end
 
     local owner = self:GetOwner()
 
@@ -613,8 +615,6 @@ function SWEP:DoShellEject()
     ed:SetEntity(self)
     ed:SetNormal(ang:Forward())
     ed:SetMagnitude(100)
-	
-	local Eff = self:GetBuff_Override("Override_ShellEffect") or "arccw_shelleffect"
 
     local efov = {}
     efov.eff = Eff

--- a/lua/weapons/arccw_base/sh_firing.lua
+++ b/lua/weapons/arccw_base/sh_firing.lua
@@ -584,6 +584,8 @@ function SWEP:GetDispersion()
 end
 
 function SWEP:DoShellEject()
+	if self.ShellEffect and self.ShellEffect == "NONE" then return end
+
     local owner = self:GetOwner()
 
     if !IsValid(owner) then return end
@@ -597,6 +599,11 @@ function SWEP:DoShellEject()
     if !att then return end
 
     local pos, ang = att.Pos, att.Ang
+	
+	if pos and ang and self.ShellEjectPosCorrection then
+		local up, right, forward = ang:Up(), ang:Right(), ang:Forward()
+		pos = pos + up * self.ShellEjectPosCorrection.z + right * self.ShellEjectPosCorrection.x + forward * self.ShellEjectPosCorrection.y
+	end
 
     local ed = EffectData()
     ed:SetOrigin(pos)
@@ -606,14 +613,16 @@ function SWEP:DoShellEject()
     ed:SetEntity(self)
     ed:SetNormal(ang:Forward())
     ed:SetMagnitude(100)
+	
+	local Eff = self:GetBuff_Override("Override_ShellEffect") or "arccw_shelleffect"
 
     local efov = {}
-    efov.eff = "arccw_shelleffect"
+    efov.eff = Eff
     efov.fx  = ed
 
     if self:GetBuff_Hook("Hook_PreDoEffects", efov) == true then return end
 
-    util.Effect("arccw_shelleffect", ed)
+    util.Effect(Eff, ed)
 end
 
 function SWEP:DoEffects()

--- a/lua/weapons/arccw_base/sh_firing.lua
+++ b/lua/weapons/arccw_base/sh_firing.lua
@@ -331,9 +331,10 @@ function SWEP:TryBustDoor(ent, dmg)
 end
 
 function SWEP:DoShootSound(sndoverride, dsndoverride, voloverride, pitchoverride)
-    local fsound, Suppressed = self.ShootSound, self:GetBuff_Override("Silencer")
+    local fsound = self.ShootSound
+	local suppressed = self:GetBuff_Override("Silencer")
 
-    if Suppressed then
+    if suppressed then
         fsound = self.ShootSoundSilenced
     end
 
@@ -344,7 +345,7 @@ function SWEP:DoShootSound(sndoverride, dsndoverride, voloverride, pitchoverride
 
         local firstsil = self.FirstShootSoundSilenced
 
-        if Suppressed then
+        if suppressed then
             fsound = firstsil and firstsil or self.ShootSoundSilenced
         end
     end
@@ -358,7 +359,7 @@ function SWEP:DoShootSound(sndoverride, dsndoverride, voloverride, pitchoverride
 
         local lastsil = self.LastShootSoundSilenced
 
-        if Suppressed then
+        if suppressed then
             fsound = lastsil and lastsil or self.ShootSoundSilenced
         end
     end
@@ -367,7 +368,7 @@ function SWEP:DoShootSound(sndoverride, dsndoverride, voloverride, pitchoverride
 
     local distancesound = self.DistantShootSound
 
-    if Suppressed then
+    if suppressed then
         distancesound = nil
     end
 
@@ -584,9 +585,9 @@ function SWEP:GetDispersion()
 end
 
 function SWEP:DoShellEject()
-	local Eff = self:GetBuff_Override("Override_ShellEffect") or "arccw_shelleffect"
+	local eff = self:GetBuff_Override("Override_ShellEffect") or "arccw_shelleffect"
 
-	if Eff == "NONE" then return end
+	if eff == "NONE" then return end
 
     local owner = self:GetOwner()
 
@@ -603,7 +604,9 @@ function SWEP:DoShellEject()
     local pos, ang = att.Pos, att.Ang
 	
 	if pos and ang and self.ShellEjectPosCorrection then
-		local up, right, forward = ang:Up(), ang:Right(), ang:Forward()
+		local up = ang:Up()
+		local right = ang:Right()
+		local forward = ang:Forward()
 		pos = pos + up * self.ShellEjectPosCorrection.z + right * self.ShellEjectPosCorrection.x + forward * self.ShellEjectPosCorrection.y
 	end
 
@@ -617,12 +620,12 @@ function SWEP:DoShellEject()
     ed:SetMagnitude(100)
 
     local efov = {}
-    efov.eff = Eff
+    efov.eff = eff
     efov.fx  = ed
 
     if self:GetBuff_Hook("Hook_PreDoEffects", efov) == true then return end
 
-    util.Effect(Eff, ed)
+    util.Effect(eff, ed)
 end
 
 function SWEP:DoEffects()

--- a/lua/weapons/arccw_base/sh_firing.lua
+++ b/lua/weapons/arccw_base/sh_firing.lua
@@ -300,7 +300,6 @@ function SWEP:PrimaryAttack()
     end
 
     self:DoShootSound()
-	if self.DoExtraFiringEvents then self:DoExtraFiringEvents() end
     self:DoPrimaryAnim()
 
     if (self.ManualAction or self:GetBuff_Override("Override_ManualAction")) and !(self.NoLastCycle and clip == 0) then
@@ -394,14 +393,7 @@ function SWEP:DoShootSound(sndoverride, dsndoverride, voloverride, pitchoverride
 
     if distancesound then self:MyEmitSound(distancesound, 149, pitch, 0.5, CHAN_WEAPON + 1) end
 
-    if fsound then
-		self:MyEmitSound(fsound, volume, pitch, 1, CHAN_WEAPON)
-		if self.ShootSoundWorldCount > 0 and not Suppressed then
-			for i=1, self.ShootSoundWorldCount do
-				self:MyEmitSound(fsound, volume, pitch, 1, CHAN_WEAPON, true)
-			end
-		end
-	end
+    if fsound then self:MyEmitSound(fsound, volume, pitch, 1, CHAN_WEAPON) end
 
     self:GetBuff_Hook("Hook_AddShootSound", fsound, volume, pitch)
 end

--- a/lua/weapons/arccw_base/sh_firing.lua
+++ b/lua/weapons/arccw_base/sh_firing.lua
@@ -585,7 +585,7 @@ end
 
 function SWEP:DoShellEject()
 	local Eff = self:GetBuff_Override("Override_ShellEffect") or "arccw_shelleffect"
-	
+
 	if Eff == "NONE" then return end
 
     local owner = self:GetOwner()

--- a/lua/weapons/arccw_base/sh_rocket.lua
+++ b/lua/weapons/arccw_base/sh_rocket.lua
@@ -8,18 +8,39 @@ function SWEP:FireRocket(ent, vel, ang)
     local src = self:GetShootSrc()
 
     if !rocket:IsValid() then print("!!! INVALID ROUND " .. ent) return end
+	
+	local rocketAng = Angle(ang.p, ang.y, ang.r)
+	if ang and self.ShootEntityAngleCorrection then
+		local up, right, forward = ang:Up(), ang:Right(), ang:Forward()
+		rocketAng:RotateAroundAxis(up, self.ShootEntityAngleCorrection.y)
+		rocketAng:RotateAroundAxis(right, self.ShootEntityAngleCorrection.p)
+		rocketAng:RotateAroundAxis(forward, self.ShootEntityAngleCorrection.r)
+	end
 
-    rocket:SetAngles(ang)
+    rocket:SetAngles(rocketAng)
     rocket:SetPos(src)
 
     rocket:SetOwner(self:GetOwner())
+	rocket.Owner = self.Owner
     rocket.Inflictor = self
+	
+	rocket.Damage = self.Damage * math.Rand(1 - self.DamageRand, 1 + self.DamageRand)
+	rocket.BlastRadius = self.BlastRadius * math.Rand(1 - self.BlastRadiusRand, 1 + self.BlastRadiusRand)
 
+	local RealVelocity = self:GetOwner():GetAbsVelocity() + ang:Forward() * vel / ArcCW.HUToM
+	rocket.CurVel = RealVelocity -- for non-physical projectiles that move themselves
+	
     rocket:Spawn()
     rocket:Activate()
-    rocket:GetPhysicsObject():SetVelocity(self:GetOwner():GetAbsVelocity())
-    rocket:GetPhysicsObject():SetVelocityInstantaneous(ang:Forward() * vel)
-    rocket:SetCollisionGroup(rocket.CollisionGroup or COLLISION_GROUP_DEBRIS)
+	if not rocket.NoPhys then
+		rocket:SetCollisionGroup(rocket.CollisionGroup or COLLISION_GROUP_DEBRIS)
+		rocket:GetPhysicsObject():SetVelocityInstantaneous(RealVelocity)
+	end
+	
+	if rocket.Launch and rocket.SetState then
+		rocket:SetState(1)
+		rocket:Launch()
+	end
 
     if rocket.ArcCW_Killable == nil then
         rocket.ArcCW_Killable = true

--- a/lua/weapons/arccw_base/sh_rocket.lua
+++ b/lua/weapons/arccw_base/sh_rocket.lua
@@ -11,7 +11,9 @@ function SWEP:FireRocket(ent, vel, ang)
 	
 	local rocketAng = Angle(ang.p, ang.y, ang.r)
 	if ang and self.ShootEntityAngleCorrection then
-		local up, right, forward = ang:Up(), ang:Right(), ang:Forward()
+		local up = ang:Up()
+		local right = ang:Right()
+		local forward = ang:Forward()
 		rocketAng:RotateAroundAxis(up, self.ShootEntityAngleCorrection.y)
 		rocketAng:RotateAroundAxis(right, self.ShootEntityAngleCorrection.p)
 		rocketAng:RotateAroundAxis(forward, self.ShootEntityAngleCorrection.r)

--- a/lua/weapons/arccw_base/sh_util.lua
+++ b/lua/weapons/arccw_base/sh_util.lua
@@ -2,12 +2,16 @@ function SWEP:TableRandom(table)
     return table[math.random(#table)]
 end
 
-function SWEP:MyEmitSound(fsound, level, pitch, vol, chan)
+function SWEP:MyEmitSound(fsound, level, pitch, vol, chan, useWorld)
     fsound = self:GetBuff_Hook("Hook_TranslateSound", fsound) or fsound
 
     if istable(fsound) then fsound = self:TableRandom(fsound) end
 
     if fsound != "" then
-        self:EmitSound(fsound, level, pitch, vol, chan or CHAN_AUTO)
+		if useWorld then
+			sound.Play(fsound, self:GetPos() + VectorRand(), level, pitch, vol)
+		else
+			self:EmitSound(fsound, level, pitch, vol, chan or CHAN_AUTO)
+		end
     end
 end

--- a/lua/weapons/arccw_base/sh_util.lua
+++ b/lua/weapons/arccw_base/sh_util.lua
@@ -9,7 +9,7 @@ function SWEP:MyEmitSound(fsound, level, pitch, vol, chan, useWorld)
 
     if fsound != "" then
 		if useWorld then
-			sound.Play(fsound, self:GetPos() + VectorRand(), level, pitch, vol)
+			sound.Play(fsound, self.Owner:GetShootPos(), level, pitch, vol)
 		else
 			self:EmitSound(fsound, level, pitch, vol, chan or CHAN_AUTO)
 		end

--- a/lua/weapons/arccw_base/shared.lua
+++ b/lua/weapons/arccw_base/shared.lua
@@ -183,6 +183,7 @@ SWEP.EnterBipodSound = "weapons/arccw/m249/m249_coverdown.wav"
 SWEP.ExitBipodSound = "weapons/arccw/m249/m249_coverup.wav"
 SWEP.SelectUBGLSound =  "weapons/arccw/ubgl_select.wav"
 SWEP.ExitUBGLSound = "weapons/arccw/ubgl_exit.wav"
+SWEP.ShootSoundWorldCount = 0 -- every shot, play the fire sound this many more times in the world (adds volume), unless suppressed
 
 SWEP.NoFlash = nil -- disable light flash
 SWEP.MuzzleEffect = nil
@@ -190,6 +191,7 @@ SWEP.FastMuzzleEffect = nil
 SWEP.GMMuzzleEffect = false -- Use Gmod muzzle effects rather than particle effects
 SWEP.ImpactEffect = nil
 SWEP.ImpactDecal = nil
+SWEP.DoExtraFiringEvents = nil -- override this function to add custom firing events
 
 SWEP.ShellModel = "models/shells/shell_556.mdl"
 SWEP.ShellMaterial = nil

--- a/lua/weapons/arccw_base/shared.lua
+++ b/lua/weapons/arccw_base/shared.lua
@@ -193,6 +193,8 @@ SWEP.ImpactDecal = nil
 
 SWEP.ShellModel = "models/shells/shell_556.mdl"
 SWEP.ShellMaterial = nil
+SWEP.ShellEffect = nil
+SWEP.ShellEjectPosCorrection = nil
 SWEP.ShellScale = 1
 SWEP.ShellPhysScale = 1
 SWEP.ShellPitch = 100

--- a/lua/weapons/arccw_base/shared.lua
+++ b/lua/weapons/arccw_base/shared.lua
@@ -183,7 +183,6 @@ SWEP.EnterBipodSound = "weapons/arccw/m249/m249_coverdown.wav"
 SWEP.ExitBipodSound = "weapons/arccw/m249/m249_coverup.wav"
 SWEP.SelectUBGLSound =  "weapons/arccw/ubgl_select.wav"
 SWEP.ExitUBGLSound = "weapons/arccw/ubgl_exit.wav"
-SWEP.ShootSoundWorldCount = 0 -- every shot, play the fire sound this many more times in the world (adds volume), unless suppressed
 
 SWEP.NoFlash = nil -- disable light flash
 SWEP.MuzzleEffect = nil
@@ -191,7 +190,6 @@ SWEP.FastMuzzleEffect = nil
 SWEP.GMMuzzleEffect = false -- Use Gmod muzzle effects rather than particle effects
 SWEP.ImpactEffect = nil
 SWEP.ImpactDecal = nil
-SWEP.DoExtraFiringEvents = nil -- override this function to add custom firing events
 
 SWEP.ShellModel = "models/shells/shell_556.mdl"
 SWEP.ShellMaterial = nil


### PR DESCRIPTION
- put trybustdoor into its own func so that it can be easily overridden with different door breaching behavior
- changed MyEmitSound to have another argument that lets you use the chad sound.Play instead of the virgin EmitSound
- added a buff that can override the shell effect
- added a way to tweak shell eject positions
- fixed a rocket velocity bug
- generally added the code necessary for FireRocket() to actually be useful instead of a garbage func that was never tested