### PR TITLE
Don't strip swep - when ammo ends

### DIFF
--- a/lua/weapons/arccw_base/sh_grenade.lua
+++ b/lua/weapons/arccw_base/sh_grenade.lua
@@ -72,8 +72,8 @@ function SWEP:Throw()
         if self:Clip1() == 0 and self:Ammo1() >= 1 and !self.Singleton then
             self:SetClip1(1)
             self:GetOwner():SetAmmo(self:Ammo1() - 1, self.Primary.Ammo)
-        else
-            self:GetOwner():StripWeapon(self:GetClass())
+        elseif !self.Disposable then
+                self:GetOwner():StripWeapon(self:GetClass())
         end
     end)
     self:SetTimer(self:GetAnimKeyTime("throw"), function()


### PR DESCRIPTION
Usefull for C4
When ammo ends, it prevent remove you activator

SWEP.Disposable = true - dont remove weapon when ammo ends

This don't broke old sweps