### PR TITLE
Grenade enhancements

### DIFF
--- a/lua/weapons/arccw_base/sh_anim.lua
+++ b/lua/weapons/arccw_base/sh_anim.lua
@@ -219,6 +219,10 @@ end
 
 function SWEP:PlayIdleAnimation(pred)
     local ianim = self:SelectAnimation("idle")
+    if self:GetGrenadePrimed() then
+        ianim = self:SelectAnimation("pre_throw_hold")
+    end
+
     -- (key, mult, pred, startfrom, tt, skipholster, ignorereload)
     if self:GetBuff_Override("UBGL_BaseAnims") and self:GetInUBGL()
             and self.Animations.idle_ubgl_empty and self:Clip2() <= 0 then

--- a/lua/weapons/arccw_base/sh_grenade.lua
+++ b/lua/weapons/arccw_base/sh_grenade.lua
@@ -19,10 +19,14 @@ function SWEP:PreThrow()
 
     self:SetNextPrimaryFire(CurTime() + self.PullPinTime)
 
-    self:SetGrenadePrimed(true)
-
     self.GrenadePrimeTime = CurTime()
     self.GrenadePrimeAlt = self:GetOwner():KeyDown(IN_ATTACK2)
+
+    self:SetGrenadePrimed(true)
+
+    if (!self.GrenadePrimeAlt and self:GetBuff("CookPrimFire",true)) or (self.GrenadePrimeAlt and self:GetBuff("CookAltFire",true)) then
+        self.isCooked = true
+    end
 
     self:GetBuff_Hook("Hook_PreThrow")
 end
@@ -30,11 +34,15 @@ end
 function SWEP:Throw()
     if self:GetNextPrimaryFire() > CurTime() then return end
 
+    local isCooked = self.isCooked
     self:SetGrenadePrimed(false)
+    self.isCooked = nil
+
+    print(isCooked)
 
     self:PlayAnimation("throw", 1, false, 0, true)
 
-    local heldtime = (CurTime() - self.GrenadePrimeTime)
+    local heldtime = isCooked and (CurTime() - self.GrenadePrimeTime) or 0
 
     local windup = heldtime / 0.5
 

--- a/lua/weapons/arccw_base/sh_grenade.lua
+++ b/lua/weapons/arccw_base/sh_grenade.lua
@@ -21,7 +21,6 @@ function SWEP:PreThrow()
 
     self.GrenadePrimeTime = CurTime()
     self.GrenadePrimeAlt = self:GetOwner():KeyDown(IN_ATTACK2)
-
     self:SetGrenadePrimed(true)
 
     if (!self.GrenadePrimeAlt and self:GetBuff("CookPrimFire",true)) or (self.GrenadePrimeAlt and self:GetBuff("CookAltFire",true)) then
@@ -38,11 +37,9 @@ function SWEP:Throw()
     self:SetGrenadePrimed(false)
     self.isCooked = nil
 
-    print(isCooked)
-
     self:PlayAnimation("throw", 1, false, 0, true)
 
-    local heldtime = isCooked and (CurTime() - self.GrenadePrimeTime) or 0
+    local heldtime = CurTime() - self.GrenadePrimeTime
 
     local windup = heldtime / 0.5
 
@@ -64,7 +61,11 @@ function SWEP:Throw()
         local ft = self:GetBuff_Override("Override_FuseTime") or self.FuseTime
 
         if ft then
-            rocket.FuseTime = ft - heldtime
+            if isCooked then
+                rocket.FuseTime = ft - heldtime
+            else
+                rocket.FuseTime = ft
+            end
         end
 
         local phys = rocket:GetPhysicsObject()

--- a/lua/weapons/arccw_base/sh_grenade.lua
+++ b/lua/weapons/arccw_base/sh_grenade.lua
@@ -23,9 +23,7 @@ function SWEP:PreThrow()
     self.GrenadePrimeAlt = self:GetOwner():KeyDown(IN_ATTACK2)
     self:SetGrenadePrimed(true)
 
-    if (!self.GrenadePrimeAlt and self:GetBuff("CookPrimFire",true)) or (self.GrenadePrimeAlt and self:GetBuff("CookAltFire",true)) then
-        self.isCooked = true
-    end
+    self.isCooked = (!self.GrenadePrimeAlt and self:GetBuff("CookPrimFire",true)) or (self.GrenadePrimeAlt and self:GetBuff("CookAltFire",true)) or nil
 
     self:GetBuff_Hook("Hook_PreThrow")
 end

--- a/lua/weapons/arccw_base/sh_think.lua
+++ b/lua/weapons/arccw_base/sh_think.lua
@@ -58,11 +58,11 @@ function SWEP:Think()
         self:SetNeedCycle(false)
     end
 
-    if self:GetGrenadePrimed() and !owner:KeyDown(IN_ATTACK) and (!game.SinglePlayer() or SERVER) then
+    if self:GetGrenadePrimed() and !(owner:KeyDown(IN_ATTACK) or owner:KeyDown(IN_ATTACK2)) and (!game.SinglePlayer() or SERVER) then
         self:Throw()
     end
 
-    if self:GetGrenadePrimed() and self.GrenadePrimeTime > 0 then
+    if self:GetGrenadePrimed() and self.GrenadePrimeTime > 0 and self.isCooked then
         local heldtime = (CurTime() - self.GrenadePrimeTime)
 
         local ft = self:GetBuff_Override("Override_FuseTime") or self.FuseTime

--- a/lua/weapons/arccw_base_nade/shared.lua
+++ b/lua/weapons/arccw_base_nade/shared.lua
@@ -18,6 +18,9 @@ SWEP.MuzzleVelocityAlt = nil -- Throwing with alt-fire will use this velocity if
 SWEP.PullPinTime = 0.25
 SWEP.FuseTime = 3.5
 
+SWEP.CookPrimFire = true
+SWEP.CookAltFire = true
+
 SWEP.ChamberSize = 0
 
 SWEP.HoldtypeHolstered = "normal"


### PR DESCRIPTION
- Added CookPrimFire and CookAltFire buffs, allowing the prevention of grade cooking by the weapon, firemodes or attachments
- Non-cooked grenades can be held indefinitely
- Grenades primed with altfire can be held
- pre_throw_hold: idle animation variant that plays when holding a primed grenade