### PR TITLE
sh_0_ttt.lua: don't override existing SWEP.Icon

### DIFF
--- a/lua/arccw/shared/sh_0_ttt.lua
+++ b/lua/arccw/shared/sh_0_ttt.lua
@@ -107,27 +107,30 @@ hook.Add("OnGamemodeLoaded", "ArcCW_TTT", function()
             end
         end
 
-        local class = wep.ClassName
-        local path = "arccw/weaponicons/" .. class
-        local path2 = "arccw/ttticons/" .. class .. ".png"
-        local path3 = "vgui/ttt/" .. class
-        local path4 = "entities/" .. class .. ".png"
+        -- Only set wep.Icon if it isn't already defined
+        if !isstring(wep.Icon) or Material(wep.Icon):IsError() then
+            local class = wep.ClassName
+            local path = "arccw/weaponicons/" .. class
+            local path2 = "arccw/ttticons/" .. class .. ".png"
+            local path3 = "vgui/ttt/" .. class
+            local path4 = "entities/" .. class .. ".png"
 
-        if !Material(path2):IsError() then
-            -- TTT icon (png)
-            wep.Icon = path2
-        elseif !Material(path3):IsError() then
-            -- TTT icon (vtf)
-            wep.Icon = path3
-        elseif !Material(path4):IsError() then
-            -- Entity spawn icon
-            wep.Icon = path4
-        elseif !Material(path):IsError() then
-            -- Kill icon
-            wep.Icon = path
-        else
-            -- fallback: display _something_
-            wep.Icon = "arccw/hud/arccw_bird.png"
+            if !Material(path2):IsError() then
+                -- TTT icon (png)
+                wep.Icon = path2
+            elseif !Material(path3):IsError() then
+                -- TTT icon (vtf)
+                wep.Icon = path3
+            elseif !Material(path4):IsError() then
+                -- Entity spawn icon
+                wep.Icon = path4
+            elseif !Material(path):IsError() then
+                -- Kill icon
+                wep.Icon = path
+            else
+                -- fallback: display _something_
+                wep.Icon = "arccw/hud/arccw_bird.png"
+            end
         end
 
     end


### PR DESCRIPTION
I ran into an issue while recreating the default TTT SWEPs with ArcCW: the current code overrides SWEP.Icon no matter what.

In my use case, I had copied over `SWEP.Icon = "vgui/ttt/icon_silenced"`, but this was being overwritten to `wep.Icon = "arccw/hud/arccw_bird.png"` since `icon_silenced` didn't match the SWEP ClassName of `weapon_ttt_sipistol`.

I think this solution is the most elegant - only attempt to automatically override the icon if it isn't already set. We check `isstring()` first because `Material()` requires a string for an argument (if we pass `nil` we get an error).