### PR TITLE
Add aimpunch cvar

### DIFF
--- a/lua/arccw/client/cl_convars.lua
+++ b/lua/arccw/client/cl_convars.lua
@@ -143,8 +143,6 @@ ArcCW.ClientConVars = {
     ["arccw_noinspect"]               = { def = 0, usri = true },
 
     ["arccw_dev_crosshair"]           = { def = 0, save = false },
-
-    ["arccw_aimpunch"]           = { def = 1, save = true, desc = "Enable aimpunch: jostling the point of aim when taking damage." },
 }
 
 for name, data in pairs(ArcCW.ClientConVars) do

--- a/lua/arccw/client/cl_convars.lua
+++ b/lua/arccw/client/cl_convars.lua
@@ -143,6 +143,8 @@ ArcCW.ClientConVars = {
     ["arccw_noinspect"]               = { def = 0, usri = true },
 
     ["arccw_dev_crosshair"]           = { def = 0, save = false },
+
+    ["arccw_aimpunch"]           = { def = 1, save = true, desc = "Enable aimpunch: jostling the point of aim when taking damage." },
 }
 
 for name, data in pairs(ArcCW.ClientConVars) do

--- a/lua/arccw/shared/sh_convars.lua
+++ b/lua/arccw/shared/sh_convars.lua
@@ -104,6 +104,8 @@ ArcCW.ConVars["attinv_giveonspawn"] = CreateConVar("arccw_attinv_giveonspawn", 0
 ArcCW.ConVars["reloadincust"] = CreateConVar("arccw_reloadincust", 0, FCVAR_ARCHIVE + FCVAR_REPLICATED, "Allow players to reload when customizing.", 0, 1)
 ArcCW.ConVars["freeaim"] = CreateConVar("arccw_freeaim", 0, FCVAR_ARCHIVE + FCVAR_REPLICATED, "", 0, 2)
 
+ArcCW.ConVars["arccw_aimpunch"] = CreateConVar("arccw_aimpunch", 1, FCVAR_ARCHIVE + FCVAR_REPLICATED, "Enable aimpunch: jostling the point of aim when taking damage.", 0, 1)
+
 -- developer stuff
 ArcCW.ConVars["reloadatts_mapcleanup"] = CreateConVar("arccw_reloadatts_mapcleanup", 0, 0, "Whether to reload ArcCW attachments on admin clean up.")
 ArcCW.ConVars["reloadatts_registerentities"] = CreateConVar("arccw_reloadatts_registerentities", 1, 0, "Register attachment entities. This may increase time to reload attachments.")

--- a/lua/arccw/shared/sh_convars.lua
+++ b/lua/arccw/shared/sh_convars.lua
@@ -104,7 +104,7 @@ ArcCW.ConVars["attinv_giveonspawn"] = CreateConVar("arccw_attinv_giveonspawn", 0
 ArcCW.ConVars["reloadincust"] = CreateConVar("arccw_reloadincust", 0, FCVAR_ARCHIVE + FCVAR_REPLICATED, "Allow players to reload when customizing.", 0, 1)
 ArcCW.ConVars["freeaim"] = CreateConVar("arccw_freeaim", 0, FCVAR_ARCHIVE + FCVAR_REPLICATED, "", 0, 2)
 
-ArcCW.ConVars["arccw_aimpunch"] = CreateConVar("arccw_aimpunch", 1, FCVAR_ARCHIVE + FCVAR_REPLICATED, "Enable aimpunch: jostling the point of aim when taking damage.", 0, 1)
+ArcCW.ConVars["aimpunch"] = CreateConVar("arccw_aimpunch", 1, FCVAR_ARCHIVE + FCVAR_REPLICATED, "Enable aimpunch: jostling the point of aim when taking damage.", 0, 1)
 
 -- developer stuff
 ArcCW.ConVars["reloadatts_mapcleanup"] = CreateConVar("arccw_reloadatts_mapcleanup", 0, 0, "Whether to reload ArcCW attachments on admin clean up.")

--- a/lua/weapons/arccw_base/cl_scope.lua
+++ b/lua/weapons/arccw_base/cl_scope.lua
@@ -68,7 +68,13 @@ function SWEP:OurViewPunch(angle)
 end
 
 function SWEP:GetOurViewPunchAngles()
-    local a = self:GetOwner():GetViewPunchAngles()
+    local a = Angle(ang0)
+    if ArcCW.ConVars["aimpunch"]:GetBool() then
+        local viewpunch = self:GetOwner():GetViewPunchAngles()
+        if viewpunch then
+            a = viewpunch
+        end
+    end
     for i = 1, 3 do a[i] = a[i] + self.ViewPunchAngle[i] * 10 end
     return a
 end


### PR DESCRIPTION
Adds a cvar to enable/disable aimpunch, the effect of the point of aim being jostled when taking damage.