### PR TITLE
Resolved depth buffer fix

### DIFF
--- a/lua/weapons/arccw_base/cl_holosight.lua
+++ b/lua/weapons/arccw_base/cl_holosight.lua
@@ -406,7 +406,7 @@ end
 
 function SWEP:FormCheapScope()
     local screen = render.GetRenderTarget()
-
+    if screen and screen:GetName()  == "_rt_resolvedfullframedepth" then return end
     render.CopyTexture( screen, rtmat_spare )
 
     render.PushRenderTarget(screen)
@@ -558,6 +558,9 @@ local defaultdot = Material("arccw/hud/hit_dot.png")
 function SWEP:DrawHolosight(hs, hsm, hsp, asight)
     -- holosight structure
     -- holosight model
+
+    local screen = render.GetRenderTarget()
+    if screen and screen:GetName()  == "_rt_resolvedfullframedepth" then return end
 
     local ref = 32
 


### PR DESCRIPTION
`DrawHolosight` and `FormCheapScope` funcs writes colors `.rgb` to [resolved depth buffer](https://wiki.facepunch.com/gmod/render.GetResolvedFullFrameDepth). So it breaks shader render. This pull request fix it.